### PR TITLE
Add --autosquash option when rebasing

### DIFF
--- a/pull.sh
+++ b/pull.sh
@@ -65,7 +65,7 @@ main () {
     git pull --rebase origin pull/$num/head
   fi
 
-  git rebase -i $curbranch # squash and test
+  git rebase -i --autosquash $curbranch # squash and test
 
   if [ $? -eq 0 ]; then
     finish "${curbranch}"


### PR DESCRIPTION
Enables for automatically squashing commits preppended by `fixup! ...`

ref: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
